### PR TITLE
chore: simplify public readme, move sso link into warning message

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,11 +1,8 @@
 # Select Health
 
-> :warning: If you are seeing this page, you are not logged in, or not a member of this organization. :warning:
+> [!CAUTION]
+> If you are seeing this page, you are currently not logged in, or not yet a member of this organization. If you believe this is incorrect, please login and visit [this link](https://github.com/orgs/SelectHealth/sso) to authenticate with SSO.
 
 ## Requesting Access
 
-To request access to this organization, please request access to the `SelectHealth GitHub` application in AccessHub.
-
-If you need to join a GitHub team, please visit this page again for further directions once you have access to the organization.
-
-If you believe you are already a member, but you are seeing this page, please try to login using SSO with [this link](https://github.com/orgs/SelectHealth/sso).
+In order to request access to this organization, please request access to the `SelectHealth GitHub` application in AccessHub. Also ensure you are a member of the correct team under the `SelectHealth Services Management` application in AccessHub.


### PR DESCRIPTION
This change hopefully makes the first troubleshooting step on our public profile page more obvious. See preview here: https://github.com/SelectHealth/.github/blob/fix/sso-link/profile/README.md